### PR TITLE
fix build error for file import

### DIFF
--- a/src/components/GithubLogin/Presentation.tsx
+++ b/src/components/GithubLogin/Presentation.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { githubLoginProps } from './githubLogin.types';
 import styles from './githubLogin.module.css';
-import githubLogo from '../../assets/github_logo.svg';
+import githubLogo from '../../assets/Github_Logo.svg';
 
 const GithubLoginPresentation: React.FC<githubLoginProps> = ({ authUrl }) => (
   <a


### PR DESCRIPTION
Date: 22/01/2024

## Description

This PR fixes the build error that we are getting in vercel for asset

The reason for that was that we renamed the assets from Github_logo to github_logo, and that was not able to figure that change.

### Documentation Updated?

- [ ] Yes
- [ ] No

<!--Additional notes about documentation update if applicable-->

### Under Feature Flag

- [ ] Yes
- [ ] No

<!--Indicate if changes are under a feature flag-->

### Database Changes

- [ ] Yes
- [ ] No

<!--Notes on any database changes-->

### Breaking Changes

- [ ] Yes
- [ ] No

<!--Notes on breaking changes or related issue tickets if applicable-->

### Development Tested?

- [ ] Yes
- [ ] No

<!--Confirmation of local testing during development-->

## Screenshots
<details>
<summary>Screenshot 1</summary>

<!-- Attach your screenshots here👇-->

</details>

<!--Attach or link to relevant screenshots or visual aids-->

## Test Coverage
<details>
<summary>Screenshot 1</summary>

<!-- Attach your screenshots here👇-->

</details>

<!--Attach Details on test coverage and outcomes-->

## Additional Notes

<!--Any additional notes, considerations or explanations for reviewers-->
